### PR TITLE
Typescript fails in printing

### DIFF
--- a/src/printing.ts
+++ b/src/printing.ts
@@ -16,7 +16,7 @@ import type { IMonitorStatus } from './types';
 const { EscPosPrinter } = NativeModules;
 const printEventEmmiter = new NativeEventEmitter(EscPosPrinter);
 
-type TCommandValue = [key: string, params: any[]];
+type TCommandValue = [ string, any[]];
 type TScalingFactors = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 /**

--- a/src/printing.ts
+++ b/src/printing.ts
@@ -16,7 +16,7 @@ import type { IMonitorStatus } from './types';
 const { EscPosPrinter } = NativeModules;
 const printEventEmmiter = new NativeEventEmitter(EscPosPrinter);
 
-type TCommandValue = [ string, any[]];
+type TCommandValue = [string, any[]];
 type TScalingFactors = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 /**


### PR DESCRIPTION
There is something wrong in `printing.ts`
Running a typecheck (v1.22.5) with `tsc -b` fails with:
```
../../node_modules/react-native-esc-pos-printer/lib/typescript/printing.d.ts:3:34 - error TS1005: ',' expected.

3 declare type TCommandValue = [key: string, params: any[]];
                                   ~

../../node_modules/react-native-esc-pos-printer/lib/typescript/printing.d.ts:3:50 - error TS1005: ',' expected.

3 declare type TCommandValue = [key: string, params: any[]];
  ```

The value `TCommandValue` should propably be `[string, any[]];`
