### PR TITLE
Method name fixed

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -60,7 +60,7 @@ interface IPrinter {
 ```javascript
 import EscPosPrinter from 'react-native-esc-pos-printer';
 
-EscPosPrinter.discovery()
+EscPosPrinter.discover()
   .then((printers) => {
     console.log(printers[0]);
     /*
@@ -81,7 +81,7 @@ EscPosPrinter.discovery()
 ```javascript
 import EscPosPrinter from 'react-native-esc-pos-printer';
 
-EscPosPrinter.discovery({ usbSerialNumber: true })
+EscPosPrinter.discover({ usbSerialNumber: true })
   .then((printers) => {
     console.log(printers[0]);
     /*


### PR DESCRIPTION
By following the old example, this error shows up in android 11.
```
[Thu Sep 30 2021 15:37:25.586]  ERROR    TypeError: _reactNativeEscPosPrinter.default.discovery is not a function. (In '_reactNativeEscPosPrinter.default.discovery()', '_reactNativeEscPosPrinter.default.discovery' is undefined)
```

But when I change from `discovery()` to `discover()` its working fine. I think this is a small typo mistake in the doc.