### PR TITLE
Silence deprecation warning for new NativeEmitter without removeListeners/addListeners

### DIFF
--- a/android/src/main/java/com/reactnativeescposprinter/EscPosPrinterModule.java
+++ b/android/src/main/java/com/reactnativeescposprinter/EscPosPrinterModule.java
@@ -495,6 +495,17 @@ public class EscPosPrinterModule extends ReactContextBaseJavaModule implements R
     }
   }
 
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+  
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }    
+
+
   private void handleCommand(int command, ReadableArray params) throws Epos2Exception, IOException {
     switch (command) {
       case PrintingCommands.COMMAND_ADD_TEXT:


### PR DESCRIPTION
We recently upgraded to React Native 0.65 and react-native-esc-pos-printer is one of the (many) libraries it complains about.

The fix is stolen from react-native-reanimated. It just adds placeholder functions for the required interface to silence the warning.

Warning looks like:
```
new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```

It's triggered when the event emitter is attached to the RN module in `androidPermissions.ts`.