### PR TITLE
Feature: allow passing scanning timeouts

### DIFF
--- a/android/src/main/java/com/reactnativeescposprinter/EscPosPrinterDiscoveryModule.java
+++ b/android/src/main/java/com/reactnativeescposprinter/EscPosPrinterDiscoveryModule.java
@@ -177,20 +177,28 @@ public class EscPosPrinterDiscoveryModule extends ReactContextBaseJavaModule imp
     }
   }
 
-  private void performDiscovery(MyCallbackInterface callback) {
+  private void performDiscovery(MyCallbackInterface callback, ReadableMap paramsMap) {
     final Handler handler = new Handler();
 
+    // Default to 5000 if the value is not passed.
+    int scanningTimeout = 5000 
+
+    if (paramsMap != null) {
+      if (paramsMap.hasKey("scanningTimeoutAndroid")) {
+        scanningTimeout = paramsMap.getInt("scanningTimeoutAndroid");
+      }
+    }
     final Runnable r = new Runnable() {
       public void run() {
         stopDiscovery();
         if (mPrinterList.size() > 0) {
-          sendDiscoveredDataToJS(); // will be invoked after 5 sec with acc. results
+          sendDiscoveredDataToJS(); // will be invoked after {scanningTimeout / 1000} sec with acc. results
         }
         callback.onDone("Search completed");
       }
     };
 
-    handler.postDelayed(r, 5000);
+    handler.postDelayed(r, scanningTimeout);
   }
 
   private String getUSBAddress(String target) {
@@ -265,6 +273,6 @@ public class EscPosPrinterDiscoveryModule extends ReactContextBaseJavaModule imp
       public void onDone(String result) {
         promise.resolve(result);
       }
-    });
+    }, paramsMap);
   }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,8 +6,7 @@
 4. [getPrinterCharsPerLine](#getprintercharsperlineseriesname)
 5. [startMonitorPrinter](#startmonitorprinterinterval-number)
 6. [stopMonitorPrinter](#stopmonitorprinter)
-1. [printing](./PRINTING.md)
-
+7. [printing](./PRINTING.md)
 
 ### init({ target, seriesName, language? })
 
@@ -19,7 +18,7 @@ Initializes printer using it's target and series name.
 | ------------ | :------: | :------: | :---------------------------------------------------------------------------------------------------------------------------------------------: |
 | `target`     | `string` |  `Yes`   | The connection target of a device which can be specified by connectAPI: ("TCP:192.168.192.168" "BT:00:22:15:7D:70:9C" "USB:000000000000000000") |
 | `seriesName` | `string` |  `Yes`   |                                                       Specifies the target printer model.                                                       |
-| `language`   | `string` |   `No`   |                                    Specifies the language : EPOS2_LANG_EN, EPOS2_LANG_JA, EPOS2_LANG_ZH_CN...                                   |
+| `language`   | `string` |   `No`   |                                   Specifies the language : EPOS2_LANG_EN, EPOS2_LANG_JA, EPOS2_LANG_ZH_CN...                                    |
 
 ```javascript
 import EscPosPrinter from 'react-native-esc-pos-printer';
@@ -42,9 +41,11 @@ Returns list of printers.
 
 #### params
 
-| Name              |   Type    | Required |                        Description                        |
-| ----------------- | :-------: | :------: | :-------------------------------------------------------: |
-| `usbSerialNumber` | `boolean` |   `No`   | To extract the serial number of the usb device on Android |
+| Name                     |   Type    | Required | Default |                         Description                          |
+| ------------------------ | :-------: | :------: | :-----: | :----------------------------------------------------------: |
+| `usbSerialNumber`        | `boolean` |   `No`   | `false` |  To extract the serial number of the usb device on Android   |
+| `scanningTimeoutIOS`     | `boolean` |   `No`   | `5000`  |   Timeout in milliseconds for scanning the printers on iOS   |
+| `scanningTimeoutAndroid` | `boolean` |   `No`   | `5000`  | Timeout in milliseconds for scanning the printers on Android |
 
 #### return type
 

--- a/ios/EscPosPrinterDiscovery.m
+++ b/ios/EscPosPrinterDiscovery.m
@@ -61,7 +61,7 @@ RCT_REMAP_METHOD(discover,
     // Default to 5000 if the value is not passed.
     int scanningTimeout = (int)[params[@"scanningTimeoutIOS"] integerValue] ?: 5000;
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (scanningTimeout / 1000) * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, scanningTimeout * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
         [self stopDiscovery];
         onFinish(@"Search completed");
     });

--- a/ios/EscPosPrinterDiscovery.m
+++ b/ios/EscPosPrinterDiscovery.m
@@ -17,6 +17,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_METHOD(discover,
+                 params:(NSDictionary *)params
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -27,7 +28,7 @@ RCT_REMAP_METHOD(discover,
     [self performDiscovery:^(NSString *result) {
         resolve(result);
 
-    }];
+    } params:params];
 }
 
 - (void) startDiscovery: (void(^)(NSString *))onError
@@ -55,9 +56,12 @@ RCT_REMAP_METHOD(discover,
     }
 }
 
-- (void) performDiscovery: (void(^)(NSString *))onFinish
+- (void) performDiscovery: (void(^)(NSString *))onFinish params:(NSDictionary *)params
 {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    // Default to 5000 if the value is not passed.
+    int scanningTimeout = (int)[params[@"scanningTimeoutIOS"] integerValue] ?: 5000;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (scanningTimeout / 1000) * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
         [self stopDiscovery];
         onFinish(@"Search completed");
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,14 +67,8 @@ const _default = {
             removeListener();
           }
         );
-        let promise;
-        if (Platform.OS === 'ios') {
-          promise = EscPosPrinterDiscovery.discover();
-        } else {
-          promise = EscPosPrinterDiscovery.discover(params);
-        }
 
-        promise
+        EscPosPrinterDiscovery.discover(params)
           .then(() => {
             removeListener();
             res([]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,9 @@ export interface IPrinterInitParams {
 }
 
 export interface IDiscoverParams {
+  /**
+   * Whether to extract the serial number of the usb device on Android
+   */
   usbSerialNumber?: boolean;
   /**
    * Timeout in milliseconds for scanning the printers on iOS (default 5000 - 5 seconds)

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,14 @@ export interface IPrinterInitParams {
 
 export interface IDiscoverParams {
   usbSerialNumber?: boolean;
+  /**
+   * Timeout in milliseconds for scanning the printers on iOS (default 5000 - 5 seconds)
+   */
+  scanningTimeoutIOS?: number;
+  /**
+   * Timeout in milliseconds for scanning the printers on Android (default 5000 - 5 seconds)
+   */
+  scanningTimeoutAndroid?: number;
 }
 
 export interface IMonitorStatus {


### PR DESCRIPTION
#Description

On Android 11 the default scanning timeout of 5 seconds wasn't consistently getting the results, on iOS tho 5 seconds seems to be a good default with a consistent result. So this PR adds two fields to the `discover` method:
```
scanningTimeoutIOS,
scanningTimeoutAndroid
```
to allow users to pass custom timeouts depending on the OS. 