### PR TITLE
Fix: Disable trimming of text with textLine

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -214,4 +214,5 @@ export interface ISpaceBetweenParams {
   textToWrap?: 'right' | 'left';
   textToWrapWidth?: number;
   gapSymbol?: string;
+  noTrim?: boolean;
 }

--- a/src/utils/spaceBetween.ts
+++ b/src/utils/spaceBetween.ts
@@ -62,6 +62,7 @@ export const spaceBetween = (
     .wrap(left, {
       width: leftTextWidth,
       break: true,
+      noTrim: true,
     })
     .split('\n');
 
@@ -69,6 +70,7 @@ export const spaceBetween = (
     .wrap(right, {
       width: rightTextWidth,
       break: true,
+      noTrim: true,
     })
     .split('\n');
 

--- a/src/utils/spaceBetween.ts
+++ b/src/utils/spaceBetween.ts
@@ -62,7 +62,7 @@ export const spaceBetween = (
     .wrap(left, {
       width: leftTextWidth,
       break: true,
-      noTrim: true,
+      noTrim: leftTextWidth >= left.length,
     })
     .split('\n');
 
@@ -70,7 +70,7 @@ export const spaceBetween = (
     .wrap(right, {
       width: rightTextWidth,
       break: true,
-      noTrim: true,
+      noTrim: rightTextWidth >= right.length,
     })
     .split('\n');
 

--- a/src/utils/spaceBetween.ts
+++ b/src/utils/spaceBetween.ts
@@ -48,6 +48,7 @@ export const spaceBetween = (
     textToWrap = 'left',
     textToWrapWidth,
     gapSymbol = ' ',
+    noTrim,
   }: ISpaceBetweenParams
 ): string => {
   const { leftTextWidth, rightTextWidth } = getTextsWidths(
@@ -62,7 +63,7 @@ export const spaceBetween = (
     .wrap(left, {
       width: leftTextWidth,
       break: true,
-      noTrim: leftTextWidth >= left.length,
+      noTrim,
     })
     .split('\n');
 
@@ -70,7 +71,7 @@ export const spaceBetween = (
     .wrap(right, {
       width: rightTextWidth,
       break: true,
-      noTrim: rightTextWidth >= right.length,
+      noTrim,
     })
     .split('\n');
 


### PR DESCRIPTION
There is an issue where when I use `textLine` method, it trims the beginning of the text. I tracked this issue down to the _wordwrapjs_ package. This is an issue since I want to be able to prepend spaces to some of my text lines.

For example:

```
printing.textLine(charsPerLine, {
  left: "1 Burger",
  right: "€ 5.00"
})

printing.textLine(charsPerLine, {
  left: "   + Cheese",
  right: "€ 0.10",
})
```

This would print:

```
1 Burger            € 5.00
+ Cheese            € 0.10
```

When it should have printed:

```
1 Burger            € 5.00
   + Cheese         € 0.10
```

By providing `noTrim` option to _wordwrapjs_, this issue is resolved.


