### PR TITLE
Feature - New Method: `getPrinterStatus`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,6 +118,10 @@ const _default = {
     EscPosPrinter.disconnect();
   },
 
+  getPrinterStatus() {
+    return EscPosPrinter.getPrinterStatus();
+  },
+
   startMonitorPrinter(interval: number = 5) {
     return EscPosPrinter.startMonitorPrinter(Math.max(5, Math.floor(interval)));
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import type {
   IPrinterInitParams,
   PrinterSeriesName,
   IMonitorStatus,
+  IPrinterStatus,
 } from './types';
 import {
   PRINTER_SERIES,
@@ -118,7 +119,7 @@ const _default = {
     EscPosPrinter.disconnect();
   },
 
-  getPrinterStatus() {
+  getPrinterStatus(): Promise<IPrinterStatus> {
     return EscPosPrinter.getPrinterStatus();
   },
 
@@ -149,6 +150,7 @@ export type {
   EventListenerCallback,
   IPrinter,
   PrinterSeriesName,
+  IPrinterStatus,
 };
 
 export default _default;

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,3 +197,5 @@ export interface ISpaceBetweenParams {
   gapSymbol?: string;
   noTrim?: boolean;
 }
+
+export type IPrinterStatus = IMonitorStatus;


### PR DESCRIPTION
Currently, consumers must use the monitoring method in order to retrieve the printer status, but consumers might want to use a one time status getter, which is not currently supported.

**Some use cases for example:**
* Get status by demand (for performance or product reasons)
* More control over every connection to the printer
* More flexible monitoring options (not every X seconds, but in changing intervals or whenever the app is idle)

This contribution contains changes in the native code and a RN method addition, mainly leaning on the logic provided in the `preformMonitoring` methods (and also used by this method as well in the new implementation)