### PR TITLE
fix(fixed): upgrade play-service-location to 21.0.1 to fix crashh iss…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,7 +82,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
 implementation fileTree(dir: "libs", include: ["*.jar"])
-implementation 'com.google.android.gms:play-services-location:17.1.0'
+implementation 'com.google.android.gms:play-services-location:21.0.1'
 implementation "com.facebook.react:react-native:+"
 }
 


### PR DESCRIPTION
Bump _com.google.android.gms:play-services-location_ on Android to resolve the crash due to conflicts with 3rd parties.


Fixes https://github.com/tr3v3r/react-native-esc-pos-printer/issues/160