### PR TITLE
fix(ios): prevent crash when printing images without internet connection

### DIFF
--- a/package/ios/ImageManager.m
+++ b/package/ios/ImageManager.m
@@ -6,6 +6,10 @@
 + (UIImage *)scaleImage:(UIImage *)image
              size:(CGSize)size
 {
+    if (!image || image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0) {
+        return nil;
+    }
+    
     CGFloat scale = MAX(size.width/image.size.width, size.height/image.size.height);
     CGFloat width = image.size.width * scale;
     CGFloat height = image.size.height * scale;
@@ -25,6 +29,10 @@
 + (CGSize)getImageCGSize:(UIImage *)imageData
             width:(int)width
 {
+    if (!imageData || imageData.size.width <= 0 || imageData.size.height <= 0 || width <= 0) {
+        return CGSizeZero;
+    }
+    
     NSInteger imgHeight = imageData.size.height;
     NSInteger imagWidth = imageData.size.width;
 
@@ -38,7 +46,11 @@
     if([urlString hasPrefix: @"http"] || [urlString hasPrefix: @"https"]) {
         NSURL *url = [NSURL URLWithString: urlString];
         NSData *data = [NSData dataWithContentsOfURL:url];
-        imageData = [[UIImage alloc] initWithData:data];
+        if (data && data.length > 0) {
+            imageData = [[UIImage alloc] initWithData:data];
+        } else {
+            imageData = nil;
+        }
     } else {
         imageData = [RCTConvert UIImage:imageObj];
     }

--- a/package/ios/ThePrinter.m
+++ b/package/ios/ThePrinter.m
@@ -387,8 +387,22 @@
             return EPOS2_ERR_MEMORY;
         }
         UIImage *data = [ImageManager getImageFromDictionarySource:source];
+        // Check if image loading failed (e.g., due to network issues)
+        if (data == nil) {
+            return EPOS2_ERR_PARAM;
+        }
+        
         CGSize size = [ImageManager getImageCGSize:data width:width];
+        // Check if size calculation failed (e.g., invalid image dimensions)
+        if (size.width <= 0 || size.height <= 0) {
+            return EPOS2_ERR_PARAM;
+        }
+        
         UIImage *scaledImage = [ImageManager scaleImage:data size:size];
+        // Check if image scaling failed
+        if (scaledImage == nil) {
+            return EPOS2_ERR_PARAM;
+        }
 
         int result = [epos2Printer_ addImage: scaledImage x:0 y:0 width:size.width height:size.height color:color mode:mode halftone:halftone brightness:brightness compress:compress];
         return result;


### PR DESCRIPTION
## Description
Fix crash when printing images without internet connection on iOS.

## Problem
The app crashes with `UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={472, 0}` when trying to print images while offline. This happens because:

1. Network requests fail and return `nil` data
2. Images are created with invalid dimensions (e.g., width=472, height=0)
3. `UIGraphicsBeginImageContextWithOptions` crashes when called with invalid dimensions

## Solution
Added comprehensive validation in the iOS image processing pipeline:

- **ImageManager.m**: Added checks for nil data, invalid image dimensions, and prevent division by zero
- **ThePrinter.m**: Added validation at each step of image processing and return `EPOS2_ERR_PARAM` instead of crashing

## Changes
- ✅ Validate image data before creating UIImage
- ✅ Check image dimensions before size calculations
- ✅ Validate calculated sizes before graphics context creation
- ✅ Return proper error codes instead of crashing

## Testing
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Changes are in native iOS code only (no JavaScript changes)

## Breaking Changes
None. This is a bug fix that improves error handling.

## Checklist
- [x] Code follows the project's coding standards
- [x] Changes are focused and related to the issue
- [x] Commit message follows conventional commits format
- [x] No breaking changes introduced